### PR TITLE
feat: about page

### DIFF
--- a/sites/public/cypress/support/commands.js
+++ b/sites/public/cypress/support/commands.js
@@ -15,8 +15,8 @@ Cypress.Commands.add("signIn", (email, password) => {
 })
 
 Cypress.Commands.add("signOut", () => {
-  cy.get(`[data-testid="My Account-2"]`).trigger("mouseover")
-  cy.get(`[data-testid="Sign Out-3"]`).trigger("click")
+  cy.get(`[data-testid="My Account-3"]`).trigger("mouseover")
+  cy.get(`[data-testid="Sign Out-4"]`).trigger("click")
 })
 
 Cypress.Commands.add("goNext", () => {

--- a/sites/public/cypress/support/commands.js
+++ b/sites/public/cypress/support/commands.js
@@ -16,7 +16,7 @@ Cypress.Commands.add("signIn", (email, password) => {
 
 Cypress.Commands.add("signOut", () => {
   cy.get(`[data-testid="My Account-3"]`).trigger("mouseover")
-  cy.get(`[data-testid="Sign Out-4"]`).trigger("click")
+  cy.get(`[data-testid="Sign Out-3"]`).trigger("click")
 })
 
 Cypress.Commands.add("goNext", () => {

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -24,6 +24,10 @@ const Layout = (props) => {
       title: t("nav.listings"),
       href: "/listings",
     },
+    {
+      title: t("pageTitle.about"),
+      href: "/about",
+    },
   ]
   if (process.env.housingCounselorServiceUrl) {
     menuLinks.push({

--- a/sites/public/src/pages/about.tsx
+++ b/sites/public/src/pages/about.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useContext } from "react"
+import { MarkdownSection, PageHeader, t } from "@bloom-housing/ui-components"
+import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import { UserStatus } from "../lib/constants"
+import Layout from "../layouts/application"
+
+const About = () => {
+  const { profile } = useContext(AuthContext)
+
+  useEffect(() => {
+    pushGtmEvent<PageView>({
+      event: "pageView",
+      pageTitle: "About",
+      status: profile ? UserStatus.LoggedIn : UserStatus.NotLoggedIn,
+    })
+  }, [profile])
+
+  return (
+    <Layout>
+      <PageHeader title={t("pageTitle.about")} inverse />
+      <MarkdownSection>
+        <p>{t("about.body1")}</p>
+        <p>{t("about.body2")}</p>
+        <p>{t("about.moreInfoContact")}</p>
+        <p>{t("about.thankYouPartners")}</p>
+        <p>{t("about.partnersList")}</p>
+      </MarkdownSection>
+    </Layout>
+  )
+}
+
+export default About


### PR DESCRIPTION
This PR addresses #4422

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds the content for the About page. It's sort of awkward that to get the right width, it's nested in the markdown section, even though there isn't any markdown content. We don't have a different layout that sets a max width in core right now. I'm going to add that into core as a super quick follow up (https://github.com/bloom-housing/bloom/pull/4500).

## How Can This Be Tested/Reviewed?

The width will be smaller bc the full width is a Detroit override.

Detroit's about page: https://homeconnect.detroitmi.gov/about
This PR: https://6750b68f282edf0008ed9208--bloom-detroit.netlify.app/about

The Arabic translations are missing, but present in old Detroit - I reached out offline to confirm!

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
