### PR TITLE
feat: add accessibility statement page

### DIFF
--- a/shared-helpers/src/locales/ar.json
+++ b/shared-helpers/src/locales/ar.json
@@ -908,7 +908,7 @@
   "pageDescription.welcome": "ابحث وتقدم للحصول على سكن ميسور التكلفة على بوابة إسكان٪ {regionName}",
   "pageTitle.about": "عن",
   "pageTitle.accessibilityStatement": "بيان إمكانية الوصول",
-  "pageTitle.additionalResources": "المزيد من فرص السكن",
+  "pageTitle.additionalResources": "المزيد من فرص السكن",  
   "pageTitle.feedback": "مشاركة ملاحظات الموقع",
   "pageTitle.getAssistance": "الحصول على المساعدة",
   "pageTitle.housingBasics": "أساسيات السكن بأسعار معقولة",

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -791,6 +791,7 @@
   "pageDescription.additionalResources": "Le recomendamos que busque más viviendas económicas.",
   "pageDescription.listing": "Haga su solicitud de vivienda de precio accesible en %{listingName} en %{regionName}, construida en sociedad con Exygy.",
   "pageDescription.welcome": "Busque y haga su solicitud de vivienda de precio accesible en el Portal de vivienda de %{regionName}",
+  "pageTitle.accessibilityStatement": "Declaración de Accesibilidad",
   "pageTitle.additionalResources": "Más oportunidades de vivienda",
   "pageTitle.disclaimer": "Exenciones de respaldos",
   "pageTitle.getAssistance": "Obtener asistencia",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -782,6 +782,7 @@
   "pageDescription.additionalResources": "We encourage you to browse other affordable housing resources.",
   "pageDescription.listing": "Apply for affordable housing at %{listingName} in %{regionName}, built in partnership with Exygy.",
   "pageDescription.welcome": "Search and apply for affordable housing on %{regionName}'s Housing Portal",
+  "pageTitle.accessibilityStatement": "Accessibility Statement",
   "pageTitle.additionalResources": "More Housing Opportunities",
   "pageTitle.disclaimer": "Disclaimer",
   "pageTitle.getAssistance": "Get Assistance",

--- a/sites/public/page_content/locale_overrides/bn.json
+++ b/sites/public/page_content/locale_overrides/bn.json
@@ -80,7 +80,6 @@
   "pageDescription.listing": "Exygy- এর সাথে অংশীদারিতে নির্মিত %{regionName} এ %{লিগিংনাম} -এ সাশ্রয়ী মূল্যের আবাসনের জন্য আবেদন করুন।",
   "pageDescription.welcome": "%{RegionName} এর হাউজিং পোর্টালে সাশ্রয়ী মূল্যের আবাসনের জন্য অনুসন্ধান করুন এবং আবেদন করুন",
   "pageTitle.about": "সম্পর্কিত",
-  "pageTitle.accessibilityStatement": "অ্যাক্সেসিবিলিটি স্টেটমেন্ট",
   "pageTitle.feedback": "ওয়েবসাইট প্রতিক্রিয়া শেয়ার করুন",
   "pageTitle.getAssistance": "সহায়তা নিন",
   "pageTitle.housingBasics": "সাশ্রয়ী আবাসন সংক্রান্ত সাধারণ তথ্য",

--- a/sites/public/page_content/locale_overrides/es.json
+++ b/sites/public/page_content/locale_overrides/es.json
@@ -76,7 +76,6 @@
   "pageDescription.resources": "El Departamento de Vivienda y Revitalización de la Ciudad de Detroit ha compilado una lista de recursos para ayudarlo a encontrar y mantener su vivienda. Al final de esta página, también encontrará cuatro videos breves donde podrá obtener más información sobre el proceso de solicitud de vivienda asequible.",
   "pageDescription.welcome": "Busque y haga su solicitud de vivienda de precio accesible en el Portal de vivienda de %{regionName}",
   "pageTitle.about": "Acerca de",
-  "pageTitle.accessibilityStatement": "Declaración de Accesibilidad",
   "pageTitle.additionalResources": "Más oportunidades de vivienda",
   "pageTitle.feedback": "Compartir comentarios sobre el sitio web",
   "pageTitle.getAssistance": "Obtener asistencia",

--- a/sites/public/page_content/locale_overrides/general.json
+++ b/sites/public/page_content/locale_overrides/general.json
@@ -89,7 +89,6 @@
   "pageDescription.housingBasics": "We know that finding housing can be a difficult and intimidating process. You can find several resources on this page to help you learn about affordable housing and the application process for these properties.",
   "pageDescription.resources": "The City of Detroit Housing and Revitalization Department has compiled a list of resources to help you find and maintain your housing. At the end of this page, you will also find four short videos where you can learn more about the application process for affordable housing.",
   "pageTitle.about": "About",
-  "pageTitle.accessibilityStatement": "Accessibility Statement",
   "pageTitle.additionalResources": "Additional Housing Resources",
   "pageTitle.feedback": "Share website feedback",
   "pageTitle.housingBasics": "Affordable Housing Basics",

--- a/sites/public/src/components/shared/CustomSiteFooter.tsx
+++ b/sites/public/src/components/shared/CustomSiteFooter.tsx
@@ -38,6 +38,7 @@ const CustomSiteFooter = () => {
             <Link href="/">{t("footer.contact")}</Link>
             <Link href="/privacy">{t("pageTitle.privacy")}</Link>
             <Link href="/disclaimer">{t("pageTitle.disclaimer")}</Link>
+            <Link href="/accessibility">{t("pageTitle.accessibilityStatement")}</Link>
           </div>
         </div>
       </div>

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -21,6 +21,7 @@ import {
   ReviewOrderTypeEnum,
   UnitsSummarized,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { useRouter } from "next/router"
 
 export const getGenericAddress = (bloomAddress: Address) => {
   return bloomAddress
@@ -240,4 +241,18 @@ export const downloadExternalPDF = async (fileURL: string, fileName: string) => 
   } catch (err) {
     console.log(err)
   }
+}
+
+// RenderIf component to render content based on language (used in markdown components)
+export const RenderIf = (props: { language: string; children: JSX.Element }) => {
+  const router = useRouter()
+
+  if (
+    props.language == "all" ||
+    props.language == router.locale ||
+    (router.locale == "en" && props.language == "default")
+  ) {
+    return props.children
+  }
+  return null
 }

--- a/sites/public/src/md_content/accessibility.md
+++ b/sites/public/src/md_content/accessibility.md
@@ -1,0 +1,220 @@
+<RenderIf language="en">
+
+This is an accessibility statement from the City of Detroit Housing and Revitalization Department.
+
+### Conformance Status
+
+The [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) defines best practices for designers and developers to improve accessibility of websites for people with disabilities. It defines three levels of conformance: Level A, Level AA, and Level AAA. Our goal is to deliver a web experience that achieves “Level AA” conformance according to the Web Content Accessibility Guidelines v2.1 (WCAG 2.1). We hope to continually iterate and improve Detroit Home Connect even beyond full WCAG conformance.
+
+### Feedback
+
+We welcome your feedback on the accessibility of Detroit Home Connect. Please let us know if you encounter accessibility barriers while using this website by contacting us at the email below:
+
+- E-mail: <detroithomeconnect@detroitmi.gov>
+
+### Compatibility With Browsers and Assistive Technology
+
+Detroit Home Connect is compatible with NVDA and JAWS on PC and VoiceOver on Mac, and has been tested using those assistive technologies.
+
+In keeping with the most current industry best practice, Detroit Home Connect is not compatible with Internet Explorer, as this browser has been officially retired as of June 2022.
+
+### Technical Specifications
+
+Accessibility of Detroit Home Connect relies on the following technologies to work with the particular combination of web browser and any assistive technologies or plugins installed on your computer:
+
+- HTML
+- WAI-ARIA
+- CSS
+- JavaScript
+
+These technologies are relied upon for conformance with the accessibility standards used.
+
+### Limitations and Alternatives
+
+Despite our best efforts to ensure the accessibility of Detroit Home Connect, there may be some limitations. Below is a description of some accessibility challenges that we are aware of on our site, and what we are doing to address those challenges.
+
+Known accessibility challenges for Detroit Home Connect:
+
+- **Alternative Image Text**: Alt text on listing images is automatically generated, which means that it might not exactly match the uploaded image. The images are uploaded by those that own the listing, so we cannot ensure they match the alternative text. We will remind property managers to upload images of the buildings to ensure consistency between the alternative text and image. Please reach out to the property manager, or the Detroit Home Connect support email if you encounter an issue with a listing image.
+- **“Additional Housing Resources” Page**: Some of the linked pages may not be accessible, because the linked resources are third party sites, and we do not have control over their accessibility standards. Please reach out to the property manager or the Detroit Home Connect support email if you encounter an issue with the resources pages.
+- **Heading elements**: Some heading elements are not consistent.
+
+### Assessment Approach
+
+The developer of Detroit Home Connect, Exygy, assessed the accessibility of Detroit Home Connect by the following approaches:
+
+- Self-evaluation.
+- External evaluation, which included a review from accessibility expert testers with disabilities.
+
+---
+
+### Date
+
+This statement was updated on 21 March 2023.
+
+</RenderIf>
+
+<RenderIf language="es">
+
+Esta es una declaración de accesibilidad del Departamento de Vivienda y Revitalización de la Ciudad de Detroit.
+
+### Estado de Conformidad
+
+Las [Pautas de Accesibilidad al Contenido Web (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) definen las mejores prácticas para que los diseñadores y desarrolladores mejoren la accesibilidad de los sitios web para las personas con discapacidades. Define tres niveles de conformidad: Nivel A, Nivel AA y Nivel AAA. Nuestro objetivo es ofrecer una experiencia web que logre el "Nivel AA" de conformidad con las Pautas de accesibilidad al contenido web v2.1 (WCAG 2.1). Esperamos iterar y mejorar continuamente Detroit Home Connect incluso más allá de la conformidad total con las WCAG.
+
+### Comentario
+
+Agradecemos sus comentarios sobre la accesibilidad de Detroit Home Connect. Háganos saber si encuentra barreras de accesibilidad mientras utiliza este sitio web comunicándose con nosotros al siguiente correo electrónico:
+
+- Correo electrónico: <detroithomeconnect@detroitmi.gov>
+
+### Compatibilidad Con Navegadores y Tecnología de Asistencia
+
+Detroit Home Connect es compatible con NVDA y JAWS en PC y VoiceOver en Mac, y ha sido probado con esas tecnologías de asistencia.
+
+De acuerdo con las mejores prácticas más actuales de la industria, Detroit Home Connect no es compatible con Internet Explorer, ya que este navegador se retiró oficialmente en junio de 2022.
+
+### Especificaciones Técnicas
+
+La accesibilidad de Detroit Home Connect se basa en las siguientes tecnologías para funcionar con la combinación particular de navegador web y cualquier tecnología de asistencia o complemento instalado en su computadora:
+
+- HTML
+- WAI-ARIA
+- CSS
+- JavaScript
+
+Se confía en estas tecnologías para cumplir con los estándares de accesibilidad utilizados.
+
+### Limitaciones y Alternativas
+
+A pesar de nuestros mejores esfuerzos para garantizar la accesibilidad de Detroit Home Connect, puede haber algunas limitaciones. A continuación se incluye una descripción de algunos desafíos de accesibilidad que conocemos en nuestro sitio y lo que estamos haciendo para abordar esos desafíos.
+
+Desafíos de accesibilidad conocidos para Detroit Home Connect:
+
+- **Texto de imagen alternativo**: el texto alternativo en las imágenes de la lista se genera automáticamente, lo que significa que es posible que no coincida exactamente con la imagen cargada. Las imágenes las cargan los propietarios de la lista, por lo que no podemos garantizar que coincidan con el texto alternativo. Recordaremos a los administradores de propiedades que carguen imágenes de los edificios para garantizar la coherencia entre el texto alternativo y la imagen. Comuníquese con el administrador de la propiedad o el correo electrónico de soporte de Detroit Home Connect si encuentra un problema con una imagen de listado.
+- **Página “Recursos adicionales de vivienda”**: Es posible que no se pueda acceder a algunas de las páginas vinculadas, ya que los recursos vinculados son sitios de terceros y no tenemos control sobre sus estándares de accesibilidad. Comuníquese con el administrador de la propiedad o con el correo electrónico de soporte de Detroit Home Connect si tiene algún problema con las páginas de recursos.
+- **Elementos de encabezado**: algunos elementos de encabezado no son consistentes.
+
+### Enfoque de Evaluación
+
+El desarrollador de Detroit Home Connect, Exygy, evaluó la accesibilidad de Detroit Home Connect mediante los siguientes enfoques:
+
+- Autoevaluación.
+- Evaluación externa, que incluyó la revisión de testers expertos en accesibilidad con discapacidad.
+
+---
+
+### Fecha
+
+Esta declaración se actualizó el 21 de marzo de 2023.
+
+</RenderIf>
+
+<RenderIf language="ar">
+هذا بيان إمكانية الوصول من دائرة الإسكان والتنشيط بمدينة ديترويت.
+
+### حالة التوافق
+
+[تحدد إرشادات الوصول إلى محتوى الويب (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) أفضل الممارسات للمصممين والمطورين لتحسين إمكانية الوصول إلى مواقع الويب للأشخاص ذوي الإعاقة. يحدد ثلاثة مستويات من المطابقة: المستوى A والمستوى AA والمستوى AAA. هدفنا هو تقديم تجربة ويب تحقق توافق "المستوى AA" وفقًا لإرشادات الوصول إلى محتوى الويب الإصدار 2.1 (WCAG 2.1). نأمل في تكرار وتحسين Detroit Home Connect باستمرار حتى بما يتجاوز توافق WCAG الكامل.
+
+### تعليق
+
+نرحب بتعليقاتك حول إمكانية الوصول إلى Detroit Home Connect. يرجى إعلامنا إذا واجهت حواجز الوصول أثناء استخدام هذا الموقع عن طريق الاتصال بنا على البريد الإلكتروني أدناه:
+
+- البريد الإلكتروني: <detroithomeconnect@detroitmi.gov>
+
+### التوافق مع المتصفحات والتكنولوجيا المساعدة
+
+يتوافق برنامج Detroit Home Connect مع NVDA و JAWS على الكمبيوتر الشخصي و VoiceOver على جهاز Mac ، وقد تم اختباره باستخدام تلك التقنيات المساعدة.
+
+تمشيا مع أفضل الممارسات الحالية في الصناعة ، لا يتوافق Detroit Home Connect مع Internet Explorer ، حيث تم إيقاف هذا المتصفح رسميًا اعتبارًا من يونيو 2022.
+
+### المواصفات الفنية
+
+تعتمد إمكانية الوصول إلى Detroit Home Connect على التقنيات التالية للعمل مع مجموعة معينة من مستعرض الويب وأي تقنيات مساعدة أو مكونات إضافية مثبتة على جهاز الكمبيوتر الخاص بك:
+
+- لغة البرمجة
+- WAI-ARIA
+- CSS
+- جافا سكريبت
+
+يتم الاعتماد على هذه التقنيات للتوافق مع معايير الوصول المستخدمة.
+
+### القيود والبدائل
+
+على الرغم من بذلنا قصارى جهدنا لضمان إمكانية الوصول إلى Detroit Home Connect ، فقد تكون هناك بعض القيود. فيما يلي وصف لبعض تحديات إمكانية الوصول التي ندركها على موقعنا ، وما نقوم به لمواجهة هذه التحديات.
+
+تحديات الوصول المعروفة لـ Detroit Home Connect:
+
+- **نص الصورة البد**: يتم إنشاء النص البديل تلقائيًا في قائمة الصور ، مما يعني أنه قد لا يتطابق تمامًا مع الصورة التي تم تحميلها. يتم تحميل الصور من قبل أولئك الذين يملكون القائمة ، لذلك لا يمكننا التأكد من تطابقها مع النص البديل. سنذكر مديري العقارات بتحميل صور المباني لضمان الاتساق بين النص والصورة البديلين. يرجى التواصل مع مدير الممتلكات ، أو البريد الإلكتروني الخاص بدعم Detroit Home Connect إذا واجهت مشكلة في صورة قائمة.
+- **صفحة "موارد الإسكان الإضافية"**: قد لا يمكن الوصول إلى بعض الصفحات المرتبطة ، لأن الموارد المرتبطة هي مواقع تابعة لجهات خارجية ، ولا نتحكم في معايير الوصول الخاصة بها. يرجى التواصل مع مدير الممتلكات أو البريد الإلكتروني الخاص بدعم Detroit Home Connect إذا واجهت مشكلة في صفحات الموارد.
+- **عناصر العنوان**: بعض عناصر العنوان غير متسقة.
+
+### نهج التقييم
+
+قام مطور Detroit Home Connect ، Exygy ، بتقييم إمكانية الوصول إلى Detroit Home Connect من خلال الأساليب التالية:
+
+- التقييم الذاتي.
+- التقييم الخارجي ، والذي تضمن مراجعة من مختبرين ذوي إعاقات ذوي خبرة في إمكانية الوصول.
+
+---
+
+### تاريخ
+
+تم تحديث هذا البيان في 21 مارس 2023.
+
+</RenderIf>
+<RenderIf language="bn">
+এটি সিটি অফ ডেট্রয়েট হাউজিং অ্যান্ড রিভাইটালাইজেশন ডিপার্টমেন্টের একটি অ্যাক্সেসিবিলিটি বিবৃতি।
+
+### সামঞ্জস্য অবস্থা
+
+[ওয়েব কনটেন্ট অ্যাক্সেসিবিলিটি নির্দেশিকা (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) প্রতিবন্ধী ব্যক্তিদের জন্য ওয়েবসাইটগুলির অ্যাক্সেসযোগ্যতা উন্নত করার জন্য ডিজাইনার এবং বিকাশকারীদের জন্য সর্বোত্তম অনুশীলনগুলি সংজ্ঞায়িত করে৷ এটি কনফারমেন্সের তিনটি স্তরকে সংজ্ঞায়িত করে: লেভেল A, লেভেল AA এবং লেভেল AAA। আমাদের লক্ষ্য হল একটি ওয়েব অভিজ্ঞতা প্রদান করা যা ওয়েব কন্টেন্ট অ্যাক্সেসিবিলিটি নির্দেশিকা v2.1 (WCAG 2.1) অনুযায়ী "লেভেল AA" সামঞ্জস্য অর্জন করে। আমরা সম্পূর্ণ WCAG সামঞ্জস্যের বাইরেও ডেট্রয়েট হোম কানেক্টকে ক্রমাগত পুনরাবৃত্তি এবং উন্নত করার আশা করি।
+
+### প্রতিক্রিয়া
+
+আমরা ডেট্রয়েট হোম কানেক্টের অ্যাক্সেসযোগ্যতার বিষয়ে আপনার মতামতকে স্বাগত জানাই। নীচের ইমেলে আমাদের সাথে যোগাযোগ করে এই ওয়েবসাইটটি ব্যবহার করার সময় আপনি অ্যাক্সেসযোগ্যতার বাধার সম্মুখীন হলে দয়া করে আমাদের জানান:
+
+ই-মেইল: <detroithomeconnect@detroitmi.gov>
+
+### ব্রাউজার এবং সহায়ক প্রযুক্তির সাথে সামঞ্জস্য
+
+Detroit Home Connect PC-এ NVDA এবং JAWS এবং Mac-এ VoiceOver-এর সাথে সামঞ্জস্যপূর্ণ, এবং সেই সহায়ক প্রযুক্তিগুলি ব্যবহার করে পরীক্ষা করা হয়েছে।
+
+সবচেয়ে বর্তমান শিল্পের সর্বোত্তম অনুশীলনের সাথে তাল মিলিয়ে, Detroit Home Connect ইন্টারনেট এক্সপ্লোরারের সাথে সামঞ্জস্যপূর্ণ নয়, কারণ এই ব্রাউজারটি জুন 2022 থেকে আনুষ্ঠানিকভাবে অবসর নেওয়া হয়েছে।
+
+### প্রযুক্তিগত বিবরণ
+
+ডেট্রয়েট হোম কানেক্টের অ্যাক্সেসিবিলিটি ওয়েব ব্রাউজার এবং আপনার কম্পিউটারে ইনস্টল করা যেকোনো সহায়ক প্রযুক্তি বা প্লাগইনগুলির বিশেষ সমন্বয়ের সাথে কাজ করার জন্য নিম্নলিখিত প্রযুক্তিগুলির উপর নির্ভর করে:
+
+- এইচটিএমএল
+- WAI-ARIA
+- সিএসএস
+- জাভাস্ক্রিপ্ট
+
+এই প্রযুক্তিগুলি ব্যবহার করা অ্যাক্সেসযোগ্যতার মানগুলির সাথে সামঞ্জস্যের জন্য নির্ভর করা হয়।
+
+### সীমাবদ্ধতা এবং বিকল্প
+
+ডেট্রয়েট হোম কানেক্টের অ্যাক্সেসযোগ্যতা নিশ্চিত করার জন্য আমাদের সর্বোত্তম প্রচেষ্টা সত্ত্বেও, কিছু সীমাবদ্ধতা থাকতে পারে। নীচে কিছু অ্যাক্সেসিবিলিটি চ্যালেঞ্জগুলির একটি বিবরণ রয়েছে যা আমরা আমাদের সাইটে সচেতন এবং সেই চ্যালেঞ্জগুলি মোকাবেলায় আমরা কী করছি৷
+
+ডেট্রয়েট হোম কানেক্টের জন্য পরিচিত অ্যাক্সেসিবিলিটি চ্যালেঞ্জ:
+
+- **বিকল্প চিত্র পাঠ্য**: তালিকাভুক্ত চিত্রগুলিতে Alt পাঠ্য স্বয়ংক্রিয়ভাবে তৈরি হয়, যার অর্থ এটি আপলোড করা চিত্রের সাথে ঠিক মেলে না। চিত্রগুলি তাদের দ্বারা আপলোড করা হয়েছে যারা তালিকার মালিক, তাই আমরা নিশ্চিত করতে পারি না যে সেগুলি বিকল্প পাঠ্যের সাথে মেলে৷ বিকল্প পাঠ্য এবং চিত্রের মধ্যে সামঞ্জস্যতা নিশ্চিত করতে আমরা সম্পত্তি পরিচালকদের বিল্ডিংয়ের ছবি আপলোড করার জন্য মনে করিয়ে দেব। যদি আপনি একটি তালিকা চিত্রের সাথে কোনো সমস্যার সম্মুখীন হন তাহলে অনুগ্রহ করে সম্পত্তি ব্যবস্থাপকের সাথে যোগাযোগ করুন বা ডেট্রয়েট হোম কানেক্ট সমর্থন ইমেলের সাথে যোগাযোগ করুন৷
+- **"অতিরিক্ত আবাসন সংস্থান" পৃষ্ঠা**: লিঙ্ক করা কিছু পৃষ্ঠা অ্যাক্সেসযোগ্য নাও হতে পারে, কারণ লিঙ্ক করা সংস্থানগুলি তৃতীয় পক্ষের সাইট, এবং তাদের অ্যাক্সেসযোগ্যতার মানগুলির উপর আমাদের নিয়ন্ত্রণ নেই৷ সম্পদের পৃষ্ঠাগুলিতে যদি আপনি কোনও সমস্যার সম্মুখীন হন তাহলে অনুগ্রহ করে সম্পত্তি ব্যবস্থাপক বা ডেট্রয়েট হোম কানেক্ট সমর্থন ইমেলের সাথে যোগাযোগ করুন।
+- **শিরোনাম উপাদান**: কিছু শিরোনাম উপাদান সামঞ্জস্যপূর্ণ নয়।
+
+### মূল্যায়ন পদ্ধতি
+
+ডেট্রয়েট হোম কানেক্টের বিকাশকারী, এক্সিজি, নিম্নলিখিত পদ্ধতির মাধ্যমে ডেট্রয়েট হোম কানেক্টের অ্যাক্সেসযোগ্যতা মূল্যায়ন করেছেন:
+
+- স্ব মূল্যায়ন.
+- বাহ্যিক মূল্যায়ন, যার মধ্যে অক্ষমতা সহ অ্যাক্সেসিবিলিটি বিশেষজ্ঞ পরীক্ষকদের কাছ থেকে একটি পর্যালোচনা অন্তর্ভুক্ত।
+
+---
+
+### তারিখ
+
+এই বিবৃতিটি 21 মার্চ 2023 তারিখে আপডেট করা হয়েছিল।
+
+</RenderIf>

--- a/sites/public/src/pages/accessibility.tsx
+++ b/sites/public/src/pages/accessibility.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useContext } from "react"
+import { MarkdownSection, t, PageHeader } from "@bloom-housing/ui-components"
+import Markdown from "markdown-to-jsx"
+import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import { UserStatus } from "../lib/constants"
+import Layout from "../layouts/application"
+import pageContent from "../md_content/accessibility.md"
+import { RenderIf } from "../lib/helpers"
+
+const Accessibility = () => {
+  const { profile } = useContext(AuthContext)
+
+  useEffect(() => {
+    pushGtmEvent<PageView>({
+      event: "pageView",
+      pageTitle: "Accessibility",
+      status: profile ? UserStatus.LoggedIn : UserStatus.NotLoggedIn,
+    })
+  }, [profile])
+
+  const pageTitle = <>{t("pageTitle.accessibilityStatement")}</>
+
+  return (
+    <Layout>
+      <PageHeader title={pageTitle} inverse />
+      <MarkdownSection>
+        <Markdown
+          options={{
+            overrides: {
+              RenderIf,
+            },
+          }}
+        >
+          {pageContent.toString()}
+        </Markdown>
+      </MarkdownSection>
+    </Layout>
+  )
+}
+
+export default Accessibility


### PR DESCRIPTION
This PR addresses #4420 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds accessibility statement page, and link to it in footer.

## How Can This Be Tested/Reviewed?

On footer click accessibility statement to go to ('/accessibility') page.
it should work with translations

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
