### PR TITLE
fix: new theme overrides

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -6,11 +6,13 @@
   --seeds-font-alt-sans: "Montserrat", "Open Sans", "Helvetica", "Arial", "Verdana", "sans-serif";
   --seeds-font-sans: "Montserrat", "Open Sans", "Helvetica", "Arial", "Verdana", "sans-serif";
   --seeds-font-serif: "Montserrat", "Droid Serif", "Georgia", "Times", "serif";
-  --seeds-color-primary-darker: #0b221f;
-  --seeds-color-primary-dark: #1a5049;
+  --seeds-color-primary-darker: #133a35;
+  --seeds-color-primary-dark: #1f6058;
   --seeds-color-primary: #297e73;
-  --seeds-color-primary-light: #59c9ba;
-  --seeds-color-primary-lighter: #b5e7e0;
+  --seeds-color-primary-light: #c5ece7;
+  --seeds-color-primary-lighter: #ecf9f7;
+  --seeds-bg-color-surface-primary: var(--seeds-color-primary-lighter);
+  --seeds-bg-color-surface-primary-inverse: var(--seeds-color-primary-dark);
 
   // Seeds component & class token overrides
   .seeds-button {


### PR DESCRIPTION
This PR addresses #[4712](https://github.com/bloom-housing/bloom/issues/4712)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

There are new [updated theme color tokens](https://www.figma.com/design/6BzrhGGMf6cqICuMFQc9G5/core-tokens?node-id=0-781&p=f&vars=1&var-id=4329-20013&m=dev) in Figma in Detroit. This updates the public overrides file in Detroit to use these new tokens.

## How Can This Be Tested/Reviewed?

If you check out the [deploy preview](https://deploy-preview-19--bloom-detroit.netlify.app/), you can see a few pages where we've uptaken Seeds now match the designs ([content page](https://www.figma.com/design/xqyamlgdsASkLTYlcifBwq/core-patterns?node-id=1566-35871&m=dev), [detail page](https://www.figma.com/design/xqyamlgdsASkLTYlcifBwq/core-patterns?node-id=841-14172&p=f&m=dev), etc in terms of color.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
