### PR TITLE
feat: rebase 4-1-25

### DIFF
--- a/shared-helpers/src/views/CustomIconMap.tsx
+++ b/shared-helpers/src/views/CustomIconMap.tsx
@@ -4,6 +4,7 @@ import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon"
 import ChevronLeftIcon from "@heroicons/react/20/solid/ChevronLeftIcon"
 import Clock from "@heroicons/react/24/outline/ClockIcon"
 import HomeModernIcon from "@heroicons/react/24/outline/HomeModernIcon"
+import HouseIcon from "@heroicons/react/24/outline/HomeIcon"
 import EnvelopeIcon from "@heroicons/react/24/outline/EnvelopeIcon"
 
 export const CustomIconMap = {
@@ -14,6 +15,7 @@ export const CustomIconMap = {
   clock: <Clock />,
   home: <HomeModernIcon />,
   envelope: <EnvelopeIcon />,
+  house: <HouseIcon />,
 }
 
 export type CustomIconType = keyof typeof CustomIconMap

--- a/sites/public/src/components/home/Home.module.scss
+++ b/sites/public/src/components/home/Home.module.scss
@@ -5,32 +5,30 @@
     background-image: url("/images/hero-main.jpg");
     background-size: cover;
     background-position: center;
+    width: auto;
     margin-inline: var(--seeds-s4);
     padding-block: var(--seeds-s24);
     border-radius: var(--seeds-rounded-xl);
-    --max-width-layout-desktop-margin-block: 0;
-    --max-width-layout-mobile-margin-block: 0;
     @media (--sm-only) {
       margin-inline: 0;
-      padding-block: var(--seeds-s6);
-      padding-inline: var(--seeds-s4);
+      padding-block: var(--seeds-spacer-content);
       border-radius: 0;
     }
     .hero {
       max-width: var(--seeds-screen-sm);
-      color: var(--seeds-color-gray-800);
       background-color: rgba(255, 255, 255, 0.95);
       border-radius: var(--seeds-rounded-xl);
       padding: var(--seeds-s8);
 
       @media (--sm-only) {
-        padding: var(--seeds-s6);
+        padding: var(--seeds-spacer-content);
       }
 
       .heading {
         font-family: var(--seeds-font-alt-sans);
         font-size: var(--seeds-font-size-5xl);
         font-weight: var(--seeds-font-weight-bold);
+        color: var(--seeds-text-color-dark);
         @media (--sm-only) {
           font-size: var(--seeds-font-size-3xl);
         }
@@ -38,7 +36,7 @@
       .subtitle {
         margin-block: var(--seeds-spacer-content);
         font-size: var(--seeds-font-size-lg);
-        color: var(--seeds-color-gray-750);
+        color: var(--seeds-text-color);
         @media (--sm-only) {
           margin-block-start: var(--seeds-spacer-header);
           font-size: var(--seeds-font-size-base);
@@ -55,7 +53,7 @@
     }
   }
   .resource-container {
-    background-color: var(--seeds-bg-color-canvas);
+    background-color: var(--seeds-bg-color-surface);
     padding-block: var(--seeds-spacer-container);
     .resource {
       height: 100%;

--- a/sites/public/src/components/home/Home.module.scss
+++ b/sites/public/src/components/home/Home.module.scss
@@ -7,7 +7,6 @@
     background-position: center;
     margin-inline: var(--seeds-s4);
     padding-block: var(--seeds-s24);
-    padding-inline: var(--seeds-s12);
     border-radius: var(--seeds-rounded-xl);
     --max-width-layout-desktop-margin-block: 0;
     --max-width-layout-mobile-margin-block: 0;
@@ -20,14 +19,14 @@
     .hero {
       max-width: var(--seeds-screen-sm);
       color: var(--seeds-color-gray-800);
-      background-color: rgba(255,255,255, 0.95);
+      background-color: rgba(255, 255, 255, 0.95);
       border-radius: var(--seeds-rounded-xl);
       padding: var(--seeds-s8);
 
       @media (--sm-only) {
         padding: var(--seeds-s6);
       }
-      
+
       .heading {
         font-family: var(--seeds-font-alt-sans);
         font-size: var(--seeds-font-size-5xl);
@@ -55,19 +54,23 @@
       }
     }
   }
-  .resource {
-    height: 100%;
-    h2 {
-      font-family: var(--seeds-font-alt-sans);
-      font-weight: var(--seeds-font-weight-semibold);
-    }
-    .resource-icon {
-      color: var(--seeds-color-primary);
-      background-color: var(--seeds-bg-color-surface-primary);
-      border-radius: var(--seeds-rounded-full);
-      padding: var(--seeds-s2);
-      svg {
-        fill: none;
+  .resource-container {
+    background-color: var(--seeds-bg-color-canvas);
+    padding-block: var(--seeds-spacer-container);
+    .resource {
+      height: 100%;
+      h2 {
+        font-family: var(--seeds-font-alt-sans);
+        font-weight: var(--seeds-font-weight-semibold);
+      }
+      .resource-icon {
+        color: var(--seeds-color-primary);
+        background-color: var(--seeds-bg-color-surface-primary);
+        border-radius: var(--seeds-rounded-full);
+        padding: var(--seeds-s2);
+        svg {
+          fill: none;
+        }
       }
     }
   }

--- a/sites/public/src/components/home/Home.tsx
+++ b/sites/public/src/components/home/Home.tsx
@@ -53,8 +53,8 @@ export const Home = (props: HomeProps) => {
             </div>
           </div>
         </MaxWidthLayout>
-        <MaxWidthLayout>
-          <Grid spacing="lg" className={styles["account-card-container"]}>
+        <MaxWidthLayout className={styles["resource-container"]}>
+          <Grid spacing="lg">
             <Grid.Row columns={2}>
               {props.jurisdiction && props.jurisdiction.notificationsSignUpUrl && (
                 <Grid.Cell>
@@ -81,7 +81,7 @@ export const Home = (props: HomeProps) => {
               )}
               <Grid.Cell>
                 <BloomCard
-                  iconSymbol="home"
+                  iconSymbol="house"
                   title={t("welcome.seeMoreOpportunitiesTruncated")}
                   variant={"block"}
                   headingPriority={2}

--- a/sites/public/src/components/shared/CustomSiteFooter.module.scss
+++ b/sites/public/src/components/shared/CustomSiteFooter.module.scss
@@ -12,10 +12,8 @@
 }
 
 .footer-content-container {
-  padding-inline: var(--seeds-s6);
   padding-block: var(--seeds-s12);
   @media (--md-down) {
-    padding-inline: var(--seeds-s6);
     padding-block: var(--seeds-s8);
   }
   width: 100%;
@@ -29,7 +27,6 @@
   flex-direction: column;
   align-items: flex-start;
   margin: auto;
-  max-width: var(--seeds-screen-lg);
 }
 
 .icon-container {

--- a/sites/public/src/components/shared/CustomSiteFooter.tsx
+++ b/sites/public/src/components/shared/CustomSiteFooter.tsx
@@ -1,38 +1,41 @@
 import React from "react"
 import Link from "next/link"
 import { t } from "@bloom-housing/ui-components"
+import MaxWidthLayout from "../../layouts/max-width"
 import styles from "./CustomSiteFooter.module.scss"
 import Markdown from "markdown-to-jsx"
 
 const CustomSiteFooter = () => {
   return (
-    <footer className={styles["footer-container"]}>
-      <div className={styles["footer-content-container"]}>
-        <div className={styles["footer"]}>
-          <div className={styles["icon-container"]}>
-            <img
-              className={styles["jurisdiction-icon"]}
-              src="/images/detroit-logo-white.png"
-              alt={t("footer.logoAlt")}
-            />
-          </div>
-          <div className={styles["text-container"]}>
-            <p>{t("footer.description")}</p>
-          </div>
+    <footer>
+      <MaxWidthLayout className={styles["footer-container"]}>
+        <div className={styles["footer-content-container"]}>
+          <div className={styles["footer"]}>
+            <div className={styles["icon-container"]}>
+              <img
+                className={styles["jurisdiction-icon"]}
+                src="/images/detroit-logo-white.png"
+                alt={t("footer.logoAlt")}
+              />
+            </div>
+            <div className={styles["text-container"]}>
+              <p>{t("footer.description")}</p>
+            </div>
 
-          <div className={styles["text-container"]}>
-            <p>{t("footer.forListingQuestions")}</p>
-            <p>{t("footer.pleaseContact")}</p>
-          </div>
-          <div className={styles["text-container"]}>
-            <p>{t("footer.forGeneralInquiries")}</p>
-            <p>
-              <Markdown>{t("footer.contactInfo")}</Markdown>
-            </p>
+            <div className={styles["text-container"]}>
+              <p>{t("footer.forListingQuestions")}</p>
+              <p>{t("footer.pleaseContact")}</p>
+            </div>
+            <div className={styles["text-container"]}>
+              <p>{t("footer.forGeneralInquiries")}</p>
+              <p>
+                <Markdown>{t("footer.contactInfo")}</Markdown>
+              </p>
+            </div>
           </div>
         </div>
-      </div>
-      <div
+      </MaxWidthLayout>
+      <MaxWidthLayout
         className={`${styles["footer-content-container"]} ${styles["copyright-content-container"]}`}
       >
         <div className={`${styles["footer"]} ${styles["copyright"]}`}>
@@ -44,7 +47,7 @@ const CustomSiteFooter = () => {
             <Link href="/accessibility">{t("pageTitle.accessibilityStatement")}</Link>
           </div>
         </div>
-      </div>
+      </MaxWidthLayout>
     </footer>
   )
 }

--- a/sites/public/src/layouts/max-width.module.scss
+++ b/sites/public/src/layouts/max-width.module.scss
@@ -1,12 +1,18 @@
 .max-width-layout {
-  --max-width-layout-desktop-margin-block: var(--seeds-spacer-content);
-  --max-width-layout-mobile-margin-block: var(--seeds-spacer-container);
+  --max-width-layout-desktop-margin-block: 0;
+  --max-width-layout-mobile-margin-block: 0;
+
   .layout-max-width-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
     margin-block: var(--max-width-layout-desktop-margin-block);
     padding-inline: var(--seeds-s4);
 
     @media (--md-and-up) {
       margin-block: var(--max-width-layout-mobile-margin-block);
+      padding-inline: var(--seeds-spacer-container);
     }
 
     p:not(:last-child) {
@@ -16,6 +22,6 @@
 
   .layout-max-width-content {
     max-width: var(--seeds-screen-lg);
-    margin: auto;
+    width: 100%;
   }
 }

--- a/sites/public/src/pages/404.tsx
+++ b/sites/public/src/pages/404.tsx
@@ -29,7 +29,7 @@ const ErrorPage = () => {
         {t("errors.notFound.message")}
       </Hero>
       <div className="homepage-extra">
-        <MaxWidthLayout>
+        <MaxWidthLayout className={"seeds-p-b-container"}>
           <>
             <p>{t("welcome.seeMoreOpportunities")}</p>
             <Button variant="primary-outlined" href="/additional-resources">

--- a/sites/public/src/pages/_error.tsx
+++ b/sites/public/src/pages/_error.tsx
@@ -24,7 +24,7 @@ const ErrorPage = () => {
         {t("errors.notFound.message")}
       </Hero>
       <div className="homepage-extra">
-        <MaxWidthLayout>
+        <MaxWidthLayout className={"seeds-p-b-container"}>
           <>
             <p>{t("welcome.seeMoreOpportunities")}</p>
             <Button variant="primary-outlined" href="/additional-resources">


### PR DESCRIPTION
Rebases off of latest main, and includes some token updates to use semantic tokens where we can on the homepage

## How Can This Be Tested/Reviewed?

Compare the homepage on the deploy preview to the [current homepage](https://bloom-detroit.netlify.app/). The only difference should be the text color of the main header, which was a different token in the designs. There's also from the core change a new home icon.

Note that this new core commit introduces a bug in the footer where there's a bit of extra spacing. This is fixed in a core PR: https://github.com/bloom-housing/bloom/pull/4773

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
