### PR TITLE
feat: update Accessibility page to use Seeds header

### DIFF
--- a/sites/public/src/pages/accessibility.tsx
+++ b/sites/public/src/pages/accessibility.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useContext } from "react"
-import { MarkdownSection, t, PageHeader } from "@bloom-housing/ui-components"
+import { MarkdownSection, t } from "@bloom-housing/ui-components"
 import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../lib/constants"
 import Layout from "../layouts/application"
+import { PageHeaderLayout } from "../patterns/PageHeaderLayout"
 import pageContent from "../md_content/accessibility.md"
 import { RenderIf } from "../lib/helpers"
 
@@ -22,18 +23,19 @@ const Accessibility = () => {
 
   return (
     <Layout>
-      <PageHeader title={pageTitle} inverse />
-      <MarkdownSection>
-        <Markdown
-          options={{
-            overrides: {
-              RenderIf,
-            },
-          }}
-        >
-          {pageContent.toString()}
-        </Markdown>
-      </MarkdownSection>
+      <PageHeaderLayout heading={pageTitle} inverse>
+        <MarkdownSection>
+          <Markdown
+            options={{
+              overrides: {
+                RenderIf,
+              },
+            }}
+          >
+            {pageContent.toString()}
+          </Markdown>
+        </MarkdownSection>
+      </PageHeaderLayout>
     </Layout>
   )
 }

--- a/sites/public/src/pages/accessibility.tsx
+++ b/sites/public/src/pages/accessibility.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useContext } from "react"
-import { MarkdownSection, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../lib/constants"
 import Layout from "../layouts/application"
 import { PageHeaderLayout } from "../patterns/PageHeaderLayout"
+import styles from "../patterns/PageHeaderLayout.module.scss"
 import pageContent from "../md_content/accessibility.md"
 import { RenderIf } from "../lib/helpers"
 
@@ -24,17 +25,16 @@ const Accessibility = () => {
   return (
     <Layout>
       <PageHeaderLayout heading={pageTitle} inverse>
-        <MarkdownSection>
-          <Markdown
-            options={{
-              overrides: {
-                RenderIf,
-              },
-            }}
-          >
-            {pageContent.toString()}
-          </Markdown>
-        </MarkdownSection>
+        <Markdown
+          options={{
+            overrides: {
+              RenderIf,
+            },
+          }}
+          className={styles["markdown"]}
+        >
+          {pageContent.toString()}
+        </Markdown>
       </PageHeaderLayout>
     </Layout>
   )


### PR DESCRIPTION
This PR addresses #4809

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Unlike the previous PR which did *not* address the issue in full (wow, where was my brain?! 🤪), this PR does indeed update the Accessibility page to show the new Seeds header.

## How Can This Be Tested/Reviewed?

Here is the deploy preview: https://deploy-preview-40--bloom-detroit.netlify.app/accessibility

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
