### PR TITLE
fix: link to the right page

### DIFF
--- a/sites/public/src/components/assistance/Assistance.tsx
+++ b/sites/public/src/components/assistance/Assistance.tsx
@@ -33,7 +33,7 @@ const Assistance = () => {
               iconClass={styles["item-icon"]}
             >
               <Card.Section className={styles["item-link"]}>
-                <Link href={"/how-it-works"}>{t("assistance.applyToHousingLink")}</Link>
+                <Link href={"/housing-basics"}>{t("assistance.applyToHousingLink")}</Link>
               </Card.Section>
             </BloomCard>
             <BloomCard


### PR DESCRIPTION
This PR addresses #4921

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This fixes the link on the Get Assistance page under "How to apply to affordable housing" so goes to the Affordable Housing Basics page.

## How Can This Be Tested/Reviewed?

Check the link and make sure it doesn't lead to a 404.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
