### PR TITLE
fix: update partners overrides

### DIFF
--- a/sites/partners/__tests__/components/applications/sections/FormDemographics.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormDemographics.test.tsx
@@ -57,7 +57,7 @@ describe("<FormDemographics>", () => {
     expect(screen.getByLabelText(/housing counselor/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/^other$/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/radio ad/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/alameda county hcd website/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/detroit home connect/i)).toBeInTheDocument()
     expect(screen.queryByLabelText(/government website/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/property website/i)).not.toBeInTheDocument()
   })

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -59,6 +59,7 @@
   "application.details.workInRegion": "Work in Region",
   "application.details.fullTimeStudent": "Full-time Student",
   "application.household.preferredUnit.options.fourBdrm": "4+ Bedroom",
+  "application.review.demographics.howDidYouHearOptions.jurisdictionWebsite": "Detroit Home Connect",
   "applications.addConfirmModalAddApplication": "Add application",
   "applications.addConfirmModalAddApplicationPostLottery": "A lottery has already been run for this listing.",
   "applications.addConfirmModalAddApplicationPostLotteryAreYouSure": "Are you sure you want to continue?",


### PR DESCRIPTION
This PR addresses #5083

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the partners application form to match the changes made in https://github.com/bloom-housing/bloom-detroit/pull/66

## How Can This Be Tested/Reviewed?

Ensuring there are no references to Alameda on the partner's side

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
