### PR TITLE
fix: detroit specific page titles for a11y

### DIFF
--- a/sites/public/src/components/content-pages/About.tsx
+++ b/sites/public/src/components/content-pages/About.tsx
@@ -5,9 +5,10 @@ import { PageHeaderLayout } from "../../patterns/PageHeaderLayout"
 import styles from "../../patterns/PageHeaderLayout.module.scss"
 
 const About = () => {
+  const pageTitle = t("pageTitle.about")
   return (
-    <Layout pageTitle={t("pageTitle.about")}>
-      <PageHeaderLayout heading={t("pageTitle.about")} inverse>
+    <Layout pageTitle={pageTitle}>
+      <PageHeaderLayout heading={pageTitle} inverse>
         <section className={styles["markdown"]}>
           <p>{t("about.body1")}</p>
           <br />

--- a/sites/public/src/components/content-pages/About.tsx
+++ b/sites/public/src/components/content-pages/About.tsx
@@ -6,7 +6,7 @@ import styles from "../../patterns/PageHeaderLayout.module.scss"
 
 const About = () => {
   return (
-    <Layout>
+    <Layout pageTitle={t("pageTitle.about")}>
       <PageHeaderLayout heading={t("pageTitle.about")} inverse>
         <section className={styles["markdown"]}>
           <p>{t("about.body1")}</p>

--- a/sites/public/src/components/content-pages/DisclaimerSeeds.tsx
+++ b/sites/public/src/components/content-pages/DisclaimerSeeds.tsx
@@ -20,9 +20,11 @@ const DisclaimerSeeds = () => {
     })
   }, [profile])
 
+  const pageTitle = t("pageTitle.terms")
+
   return (
-    <Layout>
-      <PageHeaderLayout heading={t("pageTitle.terms")} inverse>
+    <Layout pageTitle={pageTitle}>
+      <PageHeaderLayout heading={pageTitle} inverse>
         <Markdown
           options={{
             overrides: {

--- a/sites/public/src/components/content-pages/HousingBasics.tsx
+++ b/sites/public/src/components/content-pages/HousingBasics.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import Head from "next/head"
 import { Card, Dialog, Grid, Heading } from "@bloom-housing/ui-seeds"
 import { t } from "@bloom-housing/ui-components"
 import { GridRow } from "@bloom-housing/ui-seeds/src/layout/Grid"
@@ -25,12 +24,7 @@ const HousingBasics = () => {
 
   return (
     <>
-      <Layout>
-        <Head>
-          <title>
-            {pageTitle} - {t("nav.siteTitle")}
-          </title>
-        </Head>
+      <Layout pageTitle={pageTitle}>
         <PageHeaderLayout
           inverse
           heading={pageTitle}

--- a/sites/public/src/pages/accessibility.tsx
+++ b/sites/public/src/pages/accessibility.tsx
@@ -20,10 +20,10 @@ const Accessibility = () => {
     })
   }, [profile])
 
-  const pageTitle = <>{t("pageTitle.accessibilityStatement")}</>
+  const pageTitle = t("pageTitle.accessibilityStatement")
 
   return (
-    <Layout>
+    <Layout pageTitle={t("pageTitle.accessibilityStatement")}>
       <PageHeaderLayout heading={pageTitle} inverse>
         <Markdown
           options={{

--- a/sites/public/src/pages/feedback.tsx
+++ b/sites/public/src/pages/feedback.tsx
@@ -16,9 +16,11 @@ const Feedback = () => {
     })
   }, [profile])
 
+  const pageTitle = t("pageTitle.feedback")
+
   return (
-    <Layout>
-      <PageHeaderLayout heading={t("pageTitle.feedback")} inverse>
+    <Layout pageTitle={pageTitle}>
+      <PageHeaderLayout heading={pageTitle} inverse>
         <iframe
           src="https://docs.google.com/forms/d/e/1FAIpQLSe8Npioi4fChtWbTZUsfE23lEoeFXVn9vlCAHA9lMGWsQUAGA/viewform?embedded=true"
           width="100%"

--- a/sites/public/src/pages/terms.tsx
+++ b/sites/public/src/pages/terms.tsx
@@ -19,11 +19,11 @@ const Terms = () => {
     })
   }, [profile])
 
-  const pagetTitle = <>{t("pageTitle.termsAndConditions")}</>
+  const pageTitle = t("pageTitle.termsAndConditions")
 
   return (
-    <Layout>
-      <PageHeaderLayout heading={pagetTitle} inverse>
+    <Layout pageTitle={pageTitle}>
+      <PageHeaderLayout heading={pageTitle} inverse>
         <Markdown
           options={{
             overrides: {


### PR DESCRIPTION
Related to https://github.com/bloom-housing/bloom/pull/5185

## Description

Adds unique page titles to Detroit-specific pages

## How Can This Be Tested/Reviewed?

Ensure the about, terms, housing basics, accessibility, and feedback pages have unique page titles in the browser tab.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
