### PR TITLE
feat: update community types copy

### DIFF
--- a/api/prisma/migrations/29_update_community_types_copy/migration.sql
+++ b/api/prisma/migrations/29_update_community_types_copy/migration.sql
@@ -1,25 +1,23 @@
-UPDATE multiselect_questions
-SET options = jsonb_set(options, '{0,text}', '"I am a part of this community"')
-WHERE application_section='programs';
+UPDATE multiselect_questions SET
+  options = jsonb_set(options, '{0,text}', '"I am a part of this community"')
+  WHERE application_section = 'programs';
 
-UPDATE multiselect_questions
-SET options = jsonb_set(options, '{1,text}', '"I am not a part of this community"')
-WHERE application_section='programs';
+UPDATE multiselect_questions SET
+  options = jsonb_set(options, '{1,text}', '"I am not a part of this community"')
+  WHERE application_section = 'programs';
 
-UPDATE multiselect_questions
-SET text='Family',
-description='This property offers housing for all family types, with no age restrictions (other than the lead applicant must be over 18 years old). Contact the property manager for more information. Please select ''I am a part of this community'' to continue the application.'
-WHERE application_section='programs'
-and text='Families';
+UPDATE multiselect_questions SET
+  text = 'Family',
+  description = 'This property offers housing for all family types, with no age restrictions (other than the lead applicant must be over 18 years old). Contact the property manager for more information. Please select ''I am a part of this community'' to continue the application.'
+  WHERE application_section = 'programs'
+    and text='Families';
 
-UPDATE multiselect_questions
-SET description='This property offers housing for those experiencing homelessness, and may require additional processes that applicants must complete to qualify.'
-WHERE application_section='programs'
-and text='Supportive Housing for the Homeless';
+UPDATE multiselect_questions SET
+  description = 'This property offers housing for those experiencing homelessness, and may require additional processes that applicants must complete to qualify.'
+  WHERE application_section = 'programs'
+    and text = 'Supportive Housing for the Homeless';
 
-UPDATE multiselect_questions
-SET description='This property offers housing for those who have served active duty in branches of the U.S. Armed Forces, and were discharged under conditions other than dishonorable.'
-WHERE application_section='programs'
-and text='Veterans';
-
--- and text='Families'
+UPDATE multiselect_questions SET
+  description = 'This property offers housing for those who have served active duty in branches of the U.S. Armed Forces, and were discharged under conditions other than dishonorable.'
+  WHERE application_section = 'programs'
+    and text = 'Veterans';

--- a/api/prisma/migrations/29_update_community_types_copy/migration.sql
+++ b/api/prisma/migrations/29_update_community_types_copy/migration.sql
@@ -1,0 +1,25 @@
+UPDATE multiselect_questions
+SET options = jsonb_set(options, '{0,text}', '"I am a part of this community"')
+WHERE application_section='programs';
+
+UPDATE multiselect_questions
+SET options = jsonb_set(options, '{1,text}', '"I am not a part of this community"')
+WHERE application_section='programs';
+
+UPDATE multiselect_questions
+SET text='Family',
+description='This property offers housing for all family types, with no age restrictions (other than the lead applicant must be over 18 years old). Contact the property manager for more information. Please select ''I am a part of this community'' to continue the application.'
+WHERE application_section='programs'
+and text='Families';
+
+UPDATE multiselect_questions
+SET description='This property offers housing for those experiencing homelessness, and may require additional processes that applicants must complete to qualify.'
+WHERE application_section='programs'
+and text='Supportive Housing for the Homeless';
+
+UPDATE multiselect_questions
+SET description='This property offers housing for those who have served active duty in branches of the U.S. Armed Forces, and were discharged under conditions other than dishonorable.'
+WHERE application_section='programs'
+and text='Veterans';
+
+-- and text='Families'


### PR DESCRIPTION
This PR addresses bloom-housing/bloom#5162

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This updates the copy in the database for the various Detroit community types.

## How Can This Be Tested/Reviewed?

Local seed database doesn't exactly match prod data, but you should be able to run the SQL locally and it will mostly work (with no errors).

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
