### PR TITLE
fix: remove empty line from accessibility md files

### DIFF
--- a/sites/public/src/md_content/accessibility.md
+++ b/sites/public/src/md_content/accessibility.md
@@ -1,5 +1,4 @@
 <RenderIf language="en">
-
 This is an accessibility statement from the City of Detroit Housing and Revitalization Department.
 
 ### Conformance Status
@@ -55,7 +54,6 @@ This statement was updated on 21 March 2023.
 </RenderIf>
 
 <RenderIf language="es">
-
 Esta es una declaración de accesibilidad del Departamento de Vivienda y Revitalización de la Ciudad de Detroit.
 
 ### Estado de Conformidad


### PR DESCRIPTION
This PR addresses #5243

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Apparently it can't have an empty line at start for it to format properly.

## How Can This Be Tested/Reviewed?

http://localhost:3000/accessibility this one should be formatted properly for `en` and `es` (it worked for other languages already)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
