### PR TITLE
fix: update community type copy in script

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -603,15 +603,39 @@ export class ScriptRunnerService {
           WHERE jp.programs_id = '${prog.id}'
         `);
 
+      //obj with program title as key and updated program description as value
+      const updatedProgInfo = {
+        Families:
+          "This property offers housing for all family types, with no age restrictions (other than the lead applicant must be over 18 years old). Contact the property manager for more information. Please select ''I am a part of this community'' to continue the application.",
+        'Supportive Housing for the Homeless':
+          'This property offers housing for those experiencing homelessness, and may require additional processes that applicants must complete to qualify.',
+        Veterans:
+          'This property offers housing for those who have served active duty in branches of the U.S. Armed Forces, and were discharged under conditions other than dishonorable.',
+      };
+      const description = Object.keys(updatedProgInfo).includes(prog.title)
+        ? updatedProgInfo[prog.title]
+        : prog.description;
+      console.log(prog.title, description);
       const res: MultiselectQuestion =
         await this.multiselectQuestionService.create({
           text: prog.title,
           subText: prog.subtitle,
-          description: prog.description,
+          description: description,
           links: null,
           hideFromListing: this.resolveHideFromListings(prog),
           optOutText: null,
-          options: null,
+          options: [
+            {
+              text: 'I am a part of this community',
+              ordinal: 1,
+              exclusive: true,
+            },
+            {
+              text: 'I am not a part of this community',
+              ordinal: 2,
+              exclusive: true,
+            },
+          ],
           applicationSection:
             MultiselectQuestionsApplicationSectionEnum.programs,
           jurisdictions: jurisInfo.map((juris) => {

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -615,7 +615,7 @@ export class ScriptRunnerService {
       const description = Object.keys(updatedProgInfo).includes(prog.title)
         ? updatedProgInfo[prog.title]
         : prog.description;
-      console.log(prog.title, description);
+
       const res: MultiselectQuestion =
         await this.multiselectQuestionService.create({
           text: prog.title,

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -612,9 +612,7 @@ export class ScriptRunnerService {
         Veterans:
           'This property offers housing for those who have served active duty in branches of the U.S. Armed Forces, and were discharged under conditions other than dishonorable.',
       };
-      const description = Object.keys(updatedProgInfo).includes(prog.title)
-        ? updatedProgInfo[prog.title]
-        : prog.description;
+      const description = updatedProgInfo[prog.title] || prog.description;
 
       const res: MultiselectQuestion =
         await this.multiselectQuestionService.create({


### PR DESCRIPTION
This PR addresses #5162

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the program descriptions to match the desired detroit copy.

## How Can This Be Tested/Reviewed?

This can be tested by running a copy of detroit prod locally
`yarn prisma migrate resolve --applied 00_init
yarn db:migration:run`

And then running the migrateDetroitToMultiselectQuestions script to see the updated copy in the multiselect table

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
