### PR TITLE
fix: Lottery results remove what is raw rank link

### DIFF
--- a/sites/public/src/pages/account/application/[id]/lottery-results.tsx
+++ b/sites/public/src/pages/account/application/[id]/lottery-results.tsx
@@ -9,7 +9,7 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
   PublicLotteryResult,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { Card, Button, Heading, Icon, Message } from "@bloom-housing/ui-seeds"
+import { Card, Button, Heading, Icon } from "@bloom-housing/ui-seeds"
 import FormsLayout from "../../../../layouts/forms"
 import {
   ApplicationError,
@@ -146,7 +146,8 @@ const LotteryResults = () => {
                     <div>
                       <p>{t("account.application.lottery.rawRank")}</p>
                     </div>
-                    <div>
+                    {/* There isn’t a page for raw rank in Detroit. */}
+                    {/* <div>
                       <Button
                         className={styles["section-button"]}
                         href={"https://www.exygy.com"} // NOTE: Update per jurisdiction
@@ -155,7 +156,7 @@ const LotteryResults = () => {
                       >
                         {t("account.application.lottery.rawRankButton")}
                       </Button>
-                    </div>
+                    </div> */}
                   </Card.Section>
                   {/* Hide all preference related stuff, as we're not using preferences here */}
                   {/* <Card.Section divider={"flush"} className={"border-none"}>


### PR DESCRIPTION
This PR addresses #5395

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Comments out section with raw rank button

## How Can This Be Tested/Reviewed?

Apply for lottery listing, run lottery, publish results. On public site account in application summary it should hide raw rank button (It's not link from task, but i think it's the only place we have that button) 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
